### PR TITLE
Define CLI options types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,10 +13,12 @@ class ServerlessPackageLocationCustomizer {
       package: {
         options: {
           's3-bucket': {
-            usage: 'Specify the name of the deployment bucket'
+            usage: 'Specify the name of the deployment bucket',
+            type: 'string'
           },
           's3-path': {
-            usage: 'Specify the path to the package in the deployment bucket'
+            usage: 'Specify the path to the package in the deployment bucket',
+            type: 'string'
           }
         }
       }


### PR DESCRIPTION
### Description

Serverless is now reporting a deprecation warning regarding CLI options when using serverless-package-location-customizer

>CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
> - ServerlessPackageLocationCustomizer for "s3-bucket", "s3-path"
>
> Please report this issue in plugin issue tracker.
> Starting with next major release, this will be communicated with a thrown error.
> More info: https://serverless.com/framework/docs/deprecations/#CLI_OPTIONS_SCHEMA_V3

This pull request defines the types for "s3-bucket" & "s3-path" as type "string"

### Notes
- Will likely need a version bump if this PR is accepted