### PR TITLE
Adding hook for compile events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,13 @@ class ServerlessPackageLocationCustomizer {
         }
 
         return this.updateFunctions();
+      },
+      'after:package:compileEvents': async () => {
+        if (!this.options['s3-path']) {
+          return BbPromise.reject(new Error("Missing s3-path option"));
+        }
+
+        return this.updateEvents();
       }
     }
   }
@@ -63,6 +70,21 @@ class ServerlessPackageLocationCustomizer {
           this.serverless.cli.log('Updating Lambda function '+this.provider.naming.getNormalizedFunctionName(functionName), res);
           let s3FileName = path.basename(res.Properties.Code.S3Key);
           res.Properties.Code.S3Key = this.options['s3-path'] + '/' + s3FileName;
+        }
+     }.bind(this));
+    }
+
+  async updateEvents() {
+    _.each(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, function(res) {
+       if (res.Type === 'AWS::Lambda::Function') {
+          let s3FileName = path.basename(res.Properties.Code.S3Key);
+          
+          // Skip if not custom resources Lambda
+          if (s3FileName === this.provider.naming.getCustomResourcesArtifactName()) {
+            let functionName = res.Properties.FunctionName
+            this.serverless.cli.log('Updating Lambda function '+this.provider.naming.getNormalizedFunctionName(functionName), res);
+            res.Properties.Code.S3Key = this.options['s3-path'] + '/' + s3FileName;
+          }
         }
      }.bind(this));
   }


### PR DESCRIPTION
### Description

When using; `s3`, `cognitoUserPool`, `eventBridge`, `apiGatewayCloudWatchRole` as trigger events for a Lambda/Function in Serverless, under the hood the framework will create it's own Lambda (known as `custom-resources-lambda`) to facilitate these events (see [here](https://github.com/serverless/serverless/blob/main/lib/plugins/aws/custom-resources/index.js#L19)).

This Lambda is defined, CloudFormation template code generated and packaged up during the `package:compileEvents` hook. This hook runs after `package:compileLayers` & `package:compileFunctions` (used by this plugin) in the lifecycle.

The result of this is a the CloudFormation definition for said Lambda being added to the full template after this plugin has executed, leaving it with a randomly generated path generated [here](https://github.com/serverless/serverless/blob/main/lib/plugins/aws/package/lib/generate-artifact-directory-name.js) and assigned to `serverless.service.package.artifactDirectoryName` (S3 bucket is still honoured from `serverless.service.package.deploymentBucket`).

This pull request adds in new functionality to modify the S3Key in CloudFormation templates when the above scenarios occur.

### Notes
- Will likely need a version bump if this PR is accepted